### PR TITLE
Bind to 0.0.0.0 by default

### DIFF
--- a/elasticsearch/catalog/elasticsearch/elasticsearch.bom
+++ b/elasticsearch/catalog/elasticsearch/elasticsearch.bom
@@ -37,7 +37,14 @@ brooklyn.catalog:
       name: elasticsearch.bind.address
       label: "Bind address"
       description: |
-        The ip address to bind on - defaults to host.subnet.address
+        The ip address to bind on - defaults to 0.0.0.0
+      type: string
+      default: 0.0.0.0
+    elasticSearch.publish.address: &elasticsearchPublishAddress
+      name: elasticsearch.publish.address
+      label: "Publish address"
+      description: |
+        The ip address to publish - defaults to host.subnet.address
       type: string
   items:
     - id: elasticsearch-node
@@ -57,6 +64,7 @@ brooklyn.catalog:
           - *elasticsearchHttpPort
           - *elasticsearchTcpPort
           - *elasticsearchBindAddress
+          - *elasticsearchPublishAddress
         brooklyn.config:
           provisioning.properties:
             osFamily: centos
@@ -70,6 +78,7 @@ brooklyn.catalog:
             ELASTICSEARCH_HTTP_PORT: $brooklyn:config("elasticsearch.http.port")
             ELASTICSEARCH_TCP_PORT: $brooklyn:config("elasticsearch.tcp.port")
             ELASTICSEARCH_BIND_ADDRESS: $brooklyn:config("elasticsearch.bind.address")
+            ELASTICSEARCH_PUBLISH_ADDRESS: $brooklyn:config("elasticsearch.publish.address")
             APPLICATION_ID: $brooklyn:attributeWhenReady("application.id")
             ENTITY_ID: $brooklyn:attributeWhenReady("entity.id")
             IP_ADDRESS: $brooklyn:attributeWhenReady("host.subnet.address")
@@ -93,11 +102,13 @@ brooklyn.catalog:
             if [ -z "${ELASTICSEARCH_CLUSTER_NAME}" ]; then ELASTICSEARCH_CLUSTER_NAME="${APPLICATION_ID}"; fi
             if [ -z "${ELASTICSEARCH_NODE_NAME}" ]; then ELASTICSEARCH_NODE_NAME="${ENTITY_ID}"; fi
             if [ -z "${ELASTICSEARCH_BIND_ADDRESS}" ]; then ELASTICSEARCH_BIND_ADDRESS="${IP_ADDRESS}"; fi
+            if [ -z "${ELASTICSEARCH_PUBLISH_ADDRESS}" ]; then ELASTICSEARCH_PUBLISH_ADDRESS="${IP_ADDRESS}"; fi
 
             sudo tee /etc/elasticsearch/elasticsearch.yml <<-EOF
             cluster.name: ${ELASTICSEARCH_CLUSTER_NAME}
             node.name: ${ELASTICSEARCH_NODE_NAME}
-            network.host: ${ELASTICSEARCH_BIND_ADDRESS}
+            network.publish_host: ${ELASTICSEARCH_PUBLISH_ADDRESS}
+            network.bind_host: ${ELASTICSEARCH_BIND_ADDRESS}
             http.port: ${ELASTICSEARCH_HTTP_PORT}
             transport.tcp.port: ${ELASTICSEARCH_TCP_PORT}
             bootstrap.memory_lock: true
@@ -178,6 +189,7 @@ brooklyn.catalog:
           - *elasticsearchHttpPort
           - *elasticsearchTcpPort
           - *elasticsearchBindAddress
+          - *elasticsearchPublishAddress
         brooklyn.config:
           cluster.initial.size: 3
           dynamiccluster.memberspec:

--- a/elasticsearch/tests/elasticsearch/elasticsearch.tests.bom
+++ b/elasticsearch/tests/elasticsearch/elasticsearch.tests.bom
@@ -41,7 +41,7 @@ brooklyn.catalog:
             id: elasticsearch-cluster
             brooklyn.config:
               cluster.initial.size: 1
-              elasticsearch.bind.address: _site_
+              elasticsearch.publish.address: _site_
           - type: test-case
             name: "Elasticsearch Cluster Tests"
             brooklyn.config:

--- a/kibana/catalog/kibana/kibana.bom
+++ b/kibana/catalog/kibana/kibana.bom
@@ -38,8 +38,9 @@ brooklyn.catalog:
       - name: kibana.server.bind.address
         label: "Bind address"
         description: |
-          The kibana server bind address
+          The kibana server bind address (defaulting to 0.0.0.0)
         type: string
+        default: 0.0.0.0
       - name: elasticsearch.url
         label: "Elasticsearch URL"
         description: |

--- a/logstash/catalog/logstash/logstash.bom
+++ b/logstash/catalog/logstash/logstash.bom
@@ -30,8 +30,9 @@ brooklyn.catalog:
         - name: logstash.bind.address
           label: "Logstash bind address"
           description: |
-            The logstash bind address
+            The logstash bind address (defaults to 0.0.0.0)
           type: string
+          default: 0.0.0.0
         - name: logstash.node.name
           label: "Logstash node name"
           description: |


### PR DESCRIPTION
Also changes config of elasticsearch to add `elasticsearch.publish.address`
And semantics of bind.address so that the latter only sets the 
bind address (with publish.address defaulting to the subnet ip).

Necessary on Softlayer, where a VM has different nics for the subnet and the public addresses.