### PR TITLE
Fix cluster deployment issue as ES node cannot have the same ID

### DIFF
--- a/elasticsearch/catalog/elasticsearch/elasticsearch.bom
+++ b/elasticsearch/catalog/elasticsearch/elasticsearch.bom
@@ -137,7 +137,6 @@ brooklyn.catalog:
           - type: org.apache.brooklyn.enricher.stock.Transformer
             brooklyn.config:
               uniqueTag: elasticsearch-main-uri-enricher
-              enricher.producer: $brooklyn:entity("elasticsearch-node")
               enricher.triggerSensors:
                 - $brooklyn:sensor("host.address")
               enricher.targetSensor:
@@ -150,7 +149,6 @@ brooklyn.catalog:
           - type: org.apache.brooklyn.enricher.stock.Transformer
             brooklyn.config:
               uniqueTag: elasticsearch-main-uri-enricher
-              enricher.producer: $brooklyn:entity("elasticsearch-node")
               enricher.triggerSensors:
                 - $brooklyn:sensor("host.address")
               enricher.targetSensor:
@@ -163,7 +161,6 @@ brooklyn.catalog:
           - type: org.apache.brooklyn.enricher.stock.Transformer
             brooklyn.config:
               uniqueTag: elasticsearch-main-uri-private-enricher
-              enricher.producer: $brooklyn:entity("elasticsearch-node")
               enricher.triggerSensors:
                 - $brooklyn:sensor("host.subnet.address")
               enricher.targetSensor:


### PR DESCRIPTION
For a single node deployment, the enricher is able to find the producer `elasticsearch-node` as the ID is set in the catalog item.

However, in the case of a cluster deployment, each node needs to have a single unique ID and therefore, the enricher is unable to find the `elasticsearch-node`

Fortunately, the enricher's producers refer to the current entity so using `$brooklyn:self()` fixed the issue.