### PR TITLE
Read from start of input file

### DIFF
--- a/logstash/tests/logstash/logstash.tests.bom
+++ b/logstash/tests/logstash/logstash.tests.bom
@@ -17,6 +17,7 @@ brooklyn.catalog:
                 input {
                   file {
                     path => "/qa-test/*.log"
+                    start_position => "beginning"
                   }
                 }
               logstash.pipeline.output: |


### PR DESCRIPTION
During tests there sometimes seems to be an issue where the input file
is not read until after it is populated.  This way even if it is
populated first logstash will still produce output file.